### PR TITLE
Add scriptparser class, which executes multiline strings/string IEnumerables as a script

### DIFF
--- a/MathParser/ScriptParser.cs
+++ b/MathParser/ScriptParser.cs
@@ -8,8 +8,9 @@ namespace Mathos.Parser
 {
     public class ScriptParser
     {
-        public IReadOnlyDictionary<string, double> LocalVariables { get { return mathParser.LocalVariables; } }
-        public IReadOnlyDictionary<string, Func<double, double, double>> Operators { get { return mathParser.Operators; } }
+        public Dictionary<string, double> LocalVariables { get { return mathParser.LocalVariables; } }
+        public Dictionary<string, Func<double, double, double>> Operators { get { return mathParser.Operators; } }
+        public Dictionary<string, Func<double[], double>> LocalFunctions { get { return mathParser.LocalFunctions; } }
 
         private MathParser mathParser;
         private BooleanParser booleanParser;

--- a/MathParser/ScriptParser.cs
+++ b/MathParser/ScriptParser.cs
@@ -48,6 +48,11 @@ namespace Mathos.Parser
                 while (lineNumber < lines.Length)
                 {
                     var line = lines[lineNumber].Trim().ToLowerInvariant();
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        lineNumber++;
+                        continue;
+                    }
                     IfChainState currentState = IfChainState.Executing;
                     if (chainStates.Count > 0)
                     {

--- a/MathParser/ScriptParser.cs
+++ b/MathParser/ScriptParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Mathos.Parser
@@ -102,7 +103,7 @@ namespace Mathos.Parser
             }
             catch (Exception e)
             {
-                throw new ScriptParserException(lineNumber, e);
+                throw new ScriptParserException(lineNumber + 1, e);
             }
             return lastOutput;
         }

--- a/MathParser/ScriptParser.cs
+++ b/MathParser/ScriptParser.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Mathos.Parser
+{
+    public class ScriptParser
+    {
+        public IReadOnlyDictionary<string, double> LocalVariables { get { return mathParser.LocalVariables; } }
+        public IReadOnlyDictionary<string, Func<double, double, double>> Operators { get { return mathParser.Operators; } }
+
+        private MathParser mathParser;
+        private BooleanParser booleanParser;
+        public ScriptParser(bool loadPreDefinedFunctions = true, bool loadPreDefinedOperators = true, bool loadPreDefinedVariables = true, CultureInfo cultureInfo = null)
+        {
+            mathParser = new MathParser(loadPreDefinedFunctions, loadPreDefinedOperators, loadPreDefinedVariables, cultureInfo);
+            booleanParser = new BooleanParser(mathParser);
+        }
+
+        /// <summary>
+        /// Executes a string containg multiple lines as a script, and returns the last calculated number
+        /// </summary>
+        /// <param name="script"></param>
+        /// <returns></returns>
+        public double ExecuteMultiline(string script)
+        {
+            string[] lines = script.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            return ExecuteLines(lines);
+        }
+
+        /// <summary>
+        /// Executes a list of strings as a script, line by line, and returns the last calculated number
+        /// </summary>
+        /// <param name="linesEnumerable"></param>
+        /// <returns></returns>
+        public double ExecuteLines(IEnumerable<string> linesEnumerable)
+        {
+            var lines = linesEnumerable.ToArray();
+
+            double lastOutput = 0;
+            Stack<IfChainState> chainStates = new Stack<IfChainState>();
+            int lineNumber = 0;
+            try
+            {
+                while (lineNumber < lines.Length)
+                {
+                    var line = lines[lineNumber].Trim().ToLowerInvariant();
+                    IfChainState currentState = IfChainState.Executing;
+                    if (chainStates.Count > 0)
+                    {
+                        currentState = chainStates.Peek();
+                    }
+                    if (line.StartsWith("if"))
+                    {
+                        if (currentState == IfChainState.Executing)
+                        {
+                            string condition = line.Substring(line.IndexOf("if") + 2).Trim();
+                            var result = booleanParser.ProgrammaticallyParse(condition);
+                            bool executeIf = booleanParser.ToBoolean(result);
+                            chainStates.Push(executeIf ? IfChainState.Executing : IfChainState.NotExecuted);
+                        }
+                        else
+                        {
+                            // The if statement this if statement is in is not executing, so we push executed on the stack to make sure the contents of this don't get executed, and any following if else/else statements don't get executed either
+                            chainStates.Push(IfChainState.Executed);
+                        }
+                    }
+                    else if (line.StartsWith("else if") || line.StartsWith("elif"))
+                    {
+                        var oldState = chainStates.Pop();
+                        if (oldState == IfChainState.NotExecuted)
+                        {
+                            string condition = line.Substring(line.IndexOf("if") + 2).Trim();
+                            var result = booleanParser.ProgrammaticallyParse(condition);
+                            bool executeIf = booleanParser.ToBoolean(result);
+                            chainStates.Push(executeIf ? IfChainState.Executing : IfChainState.NotExecuted);
+                        }
+                        else
+                        {
+                            chainStates.Push(IfChainState.Executed);
+                        }
+                    }
+                    else if (line.StartsWith("else"))
+                    {
+                        var oldState = chainStates.Pop();
+                        chainStates.Push(oldState == IfChainState.NotExecuted ? IfChainState.Executing : IfChainState.Executed);
+                    }
+                    else if (line == "end if" || line == "endif")
+                    {
+                        chainStates.Pop();
+                    }
+                    else
+                    {
+                        if (currentState == IfChainState.Executing)
+                        {
+                            lastOutput = mathParser.ProgrammaticallyParse(line);
+                        }
+                    }
+                    lineNumber++;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new ScriptParserException(lineNumber, e);
+            }
+            return lastOutput;
+        }
+
+        private enum IfChainState
+        {
+            /// <summary>
+            /// No if/else if in this chain has been executed yet, so the following else/else if can be executed
+            /// </summary>
+            NotExecuted = 0,
+            /// <summary>
+            /// The current if/else if/else in this chain is executing, so we execute any code found, and any following else/else if cannot be executed
+            /// </summary>
+            Executing = 1,
+            /// <summary>
+            /// The current if/else if/else is not executing, but a previous one did, so following else/else if cannot be executed
+            /// </summary>
+            Executed = 2
+        }
+    }
+}

--- a/MathParser/ScriptParserException.cs
+++ b/MathParser/ScriptParserException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Mathos.Parser
+{
+    public sealed class ScriptParserException : Exception
+    {
+        public ScriptParserException() : base()
+        {
+        }
+
+        public ScriptParserException(string message) : base(message)
+        {
+        }
+
+        public ScriptParserException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public ScriptParserException(int line, Exception innerException) : base(innerException.GetType().Name + " on line " + line + ", " + Environment.NewLine + innerException.Message, innerException)
+        {
+        }
+    }
+}

--- a/MathParserTest/MathParserTest.csproj
+++ b/MathParserTest/MathParserTest.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BooleanParserTest.cs" />
+    <Compile Include="ScriptParserTest.cs" />
     <Compile Include="Test.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/MathParserTest/ScriptParserTest.cs
+++ b/MathParserTest/ScriptParserTest.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Mathos.Parser.Test
+{
+    [TestClass]
+    public class ScriptParserTest
+    {
+        private ScriptParser parser;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            parser = new ScriptParser();
+        }
+
+        [TestMethod]
+        public void ListScriptOutput()
+        {
+            string[] lines = new string[]
+            {
+                "let y = 5 * pi",
+                "let y = floor(y)",
+                "y"
+            };
+
+            var result15 = parser.ExecuteLines(lines);
+
+            Assert.AreEqual(15, result15);
+        }
+
+        [TestMethod]
+        public void MultilineScriptOutput()
+        {
+            string script3 =
+                "2 * 5" + Environment.NewLine +
+                "8 + 2" + Environment.NewLine +
+                "56/4" + Environment.NewLine +
+                "9 / 3";
+
+            string script5 = 
+                "let x = 5" + Environment.NewLine + 
+                "x";
+
+            var result3 = parser.ExecuteMultiline(script3);
+            var result5 = parser.ExecuteMultiline(script5);
+
+            Assert.AreEqual(3, result3);
+            Assert.AreEqual(5, result5);
+        }
+
+        [TestMethod]
+        public void NoEmptyLineOutput()
+        {
+            string script =
+                "let x = 5" + Environment.NewLine +
+                "x" + Environment.NewLine +
+                " \t" + Environment.NewLine; // <- space + tab
+
+            var result = parser.ExecuteMultiline(script);
+
+            Assert.AreEqual(5, result);
+        }
+
+        [TestMethod]
+        public void IfOutput()
+        {
+            string script1 =
+                "let x = 5" + Environment.NewLine +
+                "0" + Environment.NewLine +
+                "if (x >= 4)" + Environment.NewLine +
+                "1" + Environment.NewLine +
+                "end if";
+
+            string script0 =
+                "0" + Environment.NewLine +
+                "if (x < 4)" + Environment.NewLine +
+                "1" + Environment.NewLine +
+                "end if";
+
+            var result1 = parser.ExecuteMultiline(script1);
+            var result0 = parser.ExecuteMultiline(script0);
+
+            Assert.AreEqual(1, result1);
+            Assert.AreEqual(0, result0);
+        }
+
+        [TestMethod]
+        public void ElseIfOutput()
+        {
+            string script2 =
+                "let x = 5" + Environment.NewLine +
+                "0" + Environment.NewLine +
+                "if (x >= 6)" + Environment.NewLine +
+                "1" + Environment.NewLine +
+                "else if (x >= 3)" + Environment.NewLine +
+                "2" + Environment.NewLine +
+                "end if";
+
+            string script1 =
+                "0" + Environment.NewLine +
+                "if (x >= 4)" + Environment.NewLine +
+                "1" + Environment.NewLine +
+                "else if (x >= 3)" + Environment.NewLine +
+                "2" + Environment.NewLine +
+                "else if (x >= 2)" + Environment.NewLine +
+                "3" + Environment.NewLine +
+                "end if";
+
+            var result2 = parser.ExecuteMultiline(script2);
+            var result1 = parser.ExecuteMultiline(script1);
+
+            Assert.AreEqual(2, result2);
+            Assert.AreEqual(1, result1);
+        }
+
+        [TestMethod]
+        public void ElseOutput()
+        {
+            string script2 =
+                "let x = 5" + Environment.NewLine +
+                "0" + Environment.NewLine +
+                "if (x >= 6)" + Environment.NewLine +
+                "1" + Environment.NewLine +
+                "else" + Environment.NewLine +
+                "2" + Environment.NewLine +
+                "end if";
+
+            string script1 =
+                "0" + Environment.NewLine +
+                "if (x >= 4)" + Environment.NewLine +
+                "1" + Environment.NewLine +
+                "else if (x >= 3)" + Environment.NewLine +
+                "2" + Environment.NewLine +
+                "else" + Environment.NewLine +
+                "3" + Environment.NewLine +
+                "end if";
+
+            var result2 = parser.ExecuteMultiline(script2);
+            var result1 = parser.ExecuteMultiline(script1);
+
+            Assert.AreEqual(2, result2);
+            Assert.AreEqual(1, result1);
+        }
+
+        [TestMethod]
+        public void NestedIfs()
+        {
+            string[] lines0 = new string[]
+            {
+                "let abc = 123",
+                "0",
+                "if abc < 100",
+                    "1",
+                    "if abc > 100",
+                        "2",
+                    "end if",
+                "end if"
+            };
+
+            string[] lines4 = new string[]
+            {
+                "let abc = 123",
+                "4",
+                "if abc < 100",
+                    "1",
+                    "if abc > 100",
+                        "2",
+                    "else",
+                        "3",
+                    "end if",
+                "end if"
+            };
+
+            string[] lines2 = new string[]
+            {
+                "let abc = 123",
+                "5",
+                "if abc < 100",
+                    "1",
+                "else",
+                    "if abc > 100",
+                        "2",
+                    "end if",
+                "end if"
+            };
+
+            var result0 = parser.ExecuteLines(lines0);
+            var result4 = parser.ExecuteLines(lines4);
+            var result2 = parser.ExecuteLines(lines2);
+
+            Assert.AreEqual(0, result0);
+            Assert.AreEqual(4, result4);
+            Assert.AreEqual(2, result2);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ScriptParserException))]
+        public void ExceptionLinenumbers()
+        {
+            string[] lines = new string[]
+            {
+                "let abc = 123",
+                "5",
+                "if foo < 100", //line 3 contains undefined variable 
+                    "1",
+                "else",
+                    "if abc > 100",
+                        "2",
+                    "end if",
+                "end if"
+            };
+            try
+            {
+                parser.ExecuteLines(lines);
+            }
+            catch (ScriptParserException e)
+            {
+                Assert.IsTrue(e.Message.ToLowerInvariant().Contains("foo") && e.Message.ToLowerInvariant().Contains("line 3"));
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've added a script parser, with some simple if/else if/else logic. A script always returns with the last calculated value.
I'm thinking it might be good to add loops of some sort (that's why I've used a while loop instead of foreach, so changing lineNumber back to the start of the loop can be integrated easier later), but maybe with a property to set the maximum for how many times a loop can be executed (throw a fake stack overflow exception when the maximum is reached?)