### PR TITLE
Add logging functionality to the script parser

### DIFF
--- a/MathParser/IScriptParserLog.cs
+++ b/MathParser/IScriptParserLog.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mathos.Parser
+{
+    public interface IScriptParserLog
+    {
+        void Log(string log);
+    }
+}

--- a/MathParser/MultilineScriptParserLog.cs
+++ b/MathParser/MultilineScriptParserLog.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mathos.Parser
+{
+    /// <summary>
+    /// An implementation of <see cref="IScriptParserLog"/> that appends logs to a multiline string
+    /// </summary>
+    public class MultilineScriptParserLog : IScriptParserLog
+    {
+        private StringBuilder sb;
+        public MultilineScriptParserLog()
+        {
+            sb = new StringBuilder();
+        }
+        public string Output { get { return sb.ToString(); } }
+        public void Log(string log)
+        {
+            if (Output.Length > 0)
+            {
+                sb.Append(Environment.NewLine);
+            }
+            sb.Append(log);
+        }
+
+        public void Clear()
+        {
+            sb.Clear();
+        }
+    }
+}

--- a/MathParser/NullScriptParserLog.cs
+++ b/MathParser/NullScriptParserLog.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mathos.Parser
+{
+    /// <summary>
+    /// An implementation of <see cref="IScriptParserLog"/> that doesn't do anything with logs
+    /// </summary>
+    public sealed class NullScriptParserLog : IScriptParserLog
+    {
+        public void Log(string log)
+        {
+            //don't do anything with logs in this class
+        }
+    }
+}

--- a/MathParserTest/ScriptParserTest.cs
+++ b/MathParserTest/ScriptParserTest.cs
@@ -7,11 +7,13 @@ namespace Mathos.Parser.Test
     public class ScriptParserTest
     {
         private ScriptParser parser;
+        private MultilineScriptParserLog log;
 
         [TestInitialize]
         public void Initialize()
         {
-            parser = new ScriptParser();
+            log = new MultilineScriptParserLog();
+            parser = new ScriptParser(log);
         }
 
         [TestMethod]
@@ -219,6 +221,41 @@ namespace Mathos.Parser.Test
                 Assert.IsTrue(e.Message.ToLowerInvariant().Contains("foo") && e.Message.ToLowerInvariant().Contains("line 3"));
                 throw e;
             }
+        }
+
+        [TestMethod]
+        public void Logs()
+        {
+            string[] lines1 = new string[]
+            {
+                "let abc = 123",
+                "print(\"abc: \" abc)"
+            };
+            string[] lines2 = new string[]
+            {
+                "let x = 42",
+                "print \"answer (\" x \") = 6 * 9"
+            };
+            string[] lines3 = new string[]
+            {
+                "let x = 5 * 5",
+                "if x == 5 ^ 2",
+                    "print(\"math works, see \" 5 ^ 2)",
+                "else",
+                    "print(\"huh?\")",
+                "end if"
+            };
+
+            parser.ExecuteLines(lines1);
+            Assert.AreEqual("abc: 123", log.Output);
+
+            log.Clear();
+            parser.ExecuteLines(lines2);
+            Assert.AreEqual("answer (42) = 6 * 9", log.Output);
+
+            log.Clear();
+            parser.ExecuteLines(lines3);
+            Assert.AreEqual("math works, see 25", log.Output);
         }
     }
 }


### PR DESCRIPTION
Adds a new IScriptParserLog to the script parser, which can be used to print logs. The function used to print logs is called print by default (to prevent problems with the log function), but the name print is defined by a string so users can change it for example to output or write or something.

the print expression are build up using quotes, with all text in quotes being interpreted as literal text, and everything else being interpreted as a statement for the MathParser

For example, 

```csharp
let x = 7
print("the first number is: " x ", but 5 + 5 is " 5 + 5)
```
logs the following string to the IScriptParser

> the first number is 7, but 5 + 5 is 10

Note that this can't handle string concetenation for multiple variables with +, instead parsing them using the MathParser to a single value before printing 

Because the ScriptParser takes an IScriptParserLog, developers can define their own implementation of the logger, for example one which can log to the console or a database. I've added two different implementations so far, MultilineScriptParserLog.cs and NullScriptParserLog, which log to a multiline StringBuilder and nowhere respectively.