### PR TITLE
Variable declarator 'let' will only be matched as a standalone word.

### DIFF
--- a/MathParser/MathParser.cs
+++ b/MathParser/MathParser.cs
@@ -305,7 +305,7 @@ namespace Mathos.Parser
             string varName;
             double varValue;
 
-            if (mathExpression.Contains(VariableDeclarator))
+            if (System.Text.RegularExpressions.Regex.IsMatch(mathExpression, @"\b" + VariableDeclarator + @"\b"))
             {
                 if (mathExpression.Contains("be"))
                 {


### PR DESCRIPTION
Fixes #31.